### PR TITLE
Fix 500 error

### DIFF
--- a/lib/extended_watchers_issue_patch.rb
+++ b/lib/extended_watchers_issue_patch.rb
@@ -44,7 +44,7 @@ module ExtendedWatchersIssuePatch
           return true if visible
 
           if (usr || User.current).logged?
-            visible =  self.watched_by?(usr)
+            visible =  self.watched_by?(usr || User.current)
           end
 
           logger.error "visible_with_extwatch #{visible}"


### PR DESCRIPTION
When using this plugin with watcher groups plugin, this may cause 500 error.